### PR TITLE
Fix Vocal Entry dialog width on narrow screens

### DIFF
--- a/vocalpoint-qfield-plugin/main.qml
+++ b/vocalpoint-qfield-plugin/main.qml
@@ -42,7 +42,7 @@ Item {
         standardButtons: Dialog.Ok | Dialog.Cancel
 
         anchors.centerIn: parent
-        width: Math.min(700, parent.width - Theme.popupScreenEdgeMargin * 2)
+        width: Math.min(700, parent.width * 0.9)
         height: Math.min(dialogLayout.childrenRect.height + 120, parent.height - Theme.popupScreenEdgeMargin * 2)
 
         ColumnLayout {
@@ -103,8 +103,11 @@ Item {
             
             Label {
                 id: fieldNamesHelper
+                visible: text.length > 0
                 Layout.fillWidth: true;
-                wrapMode: TextInput.Wrap
+                Layout.minimumWidth: 0
+                Layout.preferredWidth: dialogLayout.width
+                wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                 font.pointSize: Theme.tipFont.pointSize
                 font.italic: true
                 color: Theme.secondaryTextColor


### PR DESCRIPTION
Fixes #13

Root cause:
The `fieldNamesHelper` label can contain a long list of field names. Its width can force the dialog content wider than the screen.

Changes:
- Allow `fieldNamesHelper` to shrink inside the layout.
- Wrap the field list at word boundaries, with fallback wrapping for long field names.
- Adjust dialog sizing to better fit narrow screens.

Tested:
- QField Desktop on Windows with a narrow/mobile-like window.
- QField on Android.
- Confirmed that hiding `fieldNamesHelper` fixed the issue first, then confirmed this fix keeps the helper visible without overflow.